### PR TITLE
Allow SAS uris to have custom query values.

### DIFF
--- a/lib/azure-contrib/shared_access_signature.rb
+++ b/lib/azure-contrib/shared_access_signature.rb
@@ -76,7 +76,7 @@ module Azure
 
 
         def sign
-          @uri.query_values = create_query_values(@options)
+          @uri.query_values = (@uri.query_values || {}).merge(create_query_values(@options))
           @uri.to_s
         end
 


### PR DESCRIPTION
Current implementation overrides custom uri query values and makes impossible to sign uris like i.e. "https://myaccount.blob.core.windows.net/mycontainer/myblob?comp=block&blockid=id"

This fix preserves custom query values in the uri.